### PR TITLE
Lua_helper.callback_handler: return nil if the haxe function returned null

### DIFF
--- a/llua/Lua.hx
+++ b/llua/Lua.hx
@@ -601,14 +601,14 @@ class Lua_helper {
 			default:
 				throw("> 5 arguments is not supported");
 		}
-
-		if(ret != null){
-			Convert.toLua(l, ret);
-		}
-
+		
 		/* return the number of results */
-		return 1;
-
+		if(ret == null){
+			return 0;
+		} else {
+			Convert.toLua(l, ret);
+			return 1;
+		}
 	} //callback_handler
 
 }


### PR DESCRIPTION
currently, if the haxe function return null, then the stack used here (which appear to be different than the one used to register it, as the documentation say this one is emptied after return), then it read the last input argument.

With this, it instead return nothing (which then default to nil).

I do this for the reason exposed here: https://github.com/ShadowMario/FNF-PsychEngine/issues/10737#issuecomment-1264648248