### PR TITLE
Argument limit removal

### DIFF
--- a/llua/Lua.hx
+++ b/llua/Lua.hx
@@ -577,30 +577,7 @@ class Lua_helper {
 			args[i] = Convert.fromLua(l, i + 1);
 		}
 
-		var ret:Dynamic = null;
-
-		switch (nparams) {
-			case 0:
-				ret = cbf();
-			case 1:
-				ret = cbf(args[0]);
-			case 2:
-				ret = cbf(args[0], args[1]);
-			case 3:
-				ret = cbf(args[0], args[1], args[2]);
-			case 4:
-				ret = cbf(args[0], args[1], args[2], args[3]);
-			case 5:
-				ret = cbf(args[0], args[1], args[2], args[3], args[4]);
-			case 6:
-				ret = cbf(args[0], args[1], args[2], args[3], args[4], args[5]);
-			case 7:
-				ret = cbf(args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
-			case 8:
-				ret = cbf(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]);
-			default:
-				throw("> 5 arguments is not supported");
-		}
+		var ret:Dynamic = (nparams > 0) ? Reflect.callMethod(null, cbf, args) : cbf();
 
 		if(ret != null){
 			Convert.toLua(l, ret);


### PR DESCRIPTION
Removes the big switch statement in `callback_handler`, removing the arguments limit in the process